### PR TITLE
refactor: gateway supervisor + disk logging + quit cleanup (PR-1 of v1.3.39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 .DS_Store
 Thumbs.db
 .eslintcache
+.worktrees/
 .vercel
 *.key
 *.csr

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,12 @@ import { registerIpcHandlers, getSavedLocale } from './ipc-handlers'
 import { createTray, startPolling, destroyTray } from './services/tray-manager'
 import { setupAutoUpdater, checkForUpdates } from './services/updater'
 import { startGateway } from './services/gateway'
+import { getSupervisor } from './services/gateway-supervisor'
+import { migrateGatewayPlist } from './services/onboarder'
+import {
+  flush as flushGatewayLog,
+  writeLine as writeGatewayLog
+} from './services/gateway-log-rotator'
 import { initI18nMain } from '../shared/i18n/main'
 import icon from '../../resources/icon.png?asset'
 
@@ -74,13 +80,40 @@ function createWindow(): void {
   }
 }
 
-app.on('before-quit', () => {
+let cleanupRan = false
+
+const runQuitCleanup = async (): Promise<void> => {
+  if (cleanupRan) return
+  cleanupRan = true
+  writeGatewayLog('meta', 'app quit — cleanup start')
+  try {
+    const stopPromise = getSupervisor().stop()
+    const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, 3000))
+    await Promise.race([stopPromise, timeoutPromise])
+  } catch {
+    /* best effort */
+  }
+  flushGatewayLog()
+  writeGatewayLog('meta', 'app quit — cleanup done')
+}
+
+app.on('before-quit', (event) => {
   isQuitting = true
+  if (cleanupRan) return
+  event.preventDefault()
+  void runQuitCleanup().finally(() => {
+    app.exit(0)
+  })
 })
 
 app.whenReady().then(async () => {
   await initI18nMain(getSavedLocale())
   electronApp.setAppUserModelId('com.easyclaw.app')
+
+  // One-shot launchd plist migration: adds StandardOut/Err paths so daemon
+  // crashes leave a trail under userData/logs/. No-op if already patched
+  // or on Windows.
+  void migrateGatewayPlist().catch(() => {})
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)

--- a/src/main/services/gateway-log-rotator.ts
+++ b/src/main/services/gateway-log-rotator.ts
@@ -1,0 +1,122 @@
+import { app } from 'electron'
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync
+} from 'fs'
+import { join } from 'path'
+
+const RETENTION_DAYS = 7
+const TOTAL_CAP_BYTES = 50 * 1024 * 1024
+const FILE_PREFIX = 'gateway-'
+const FILE_SUFFIX = '.log'
+
+let cachedLogsDir: string | null = null
+
+const getLogsDir = (): string => {
+  if (cachedLogsDir) return cachedLogsDir
+  const dir = join(app.getPath('userData'), 'logs')
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  } catch {
+    /* ignore — writeLine will silently fail too */
+  }
+  cachedLogsDir = dir
+  return dir
+}
+
+const dateStamp = (d: Date = new Date()): string => {
+  const yyyy = d.getUTCFullYear()
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+export const getLogPath = (date: Date = new Date()): string =>
+  join(getLogsDir(), `${FILE_PREFIX}${dateStamp(date)}${FILE_SUFFIX}`)
+
+let lastRetentionRunMs = 0
+const RETENTION_INTERVAL_MS = 60 * 60 * 1000
+
+const enforceRetention = (): void => {
+  const now = Date.now()
+  if (now - lastRetentionRunMs < RETENTION_INTERVAL_MS) return
+  lastRetentionRunMs = now
+  try {
+    const dir = getLogsDir()
+    const files = readdirSync(dir)
+      .filter((name) => name.startsWith(FILE_PREFIX) && name.endsWith(FILE_SUFFIX))
+      .map((name) => {
+        const full = join(dir, name)
+        const stat = statSync(full)
+        return { name, full, mtime: stat.mtimeMs, size: stat.size }
+      })
+      .sort((a, b) => b.mtime - a.mtime)
+
+    const cutoff = now - RETENTION_DAYS * 24 * 60 * 60 * 1000
+    let runningTotal = 0
+    for (const f of files) {
+      runningTotal += f.size
+      const tooOld = f.mtime < cutoff
+      const overCap = runningTotal > TOTAL_CAP_BYTES
+      if (tooOld || overCap) {
+        try {
+          unlinkSync(f.full)
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export type LogStream = 'stdout' | 'stderr' | 'meta'
+
+export const writeLine = (stream: LogStream, msg: string): void => {
+  if (!msg) return
+  try {
+    const ts = new Date().toISOString()
+    const line = `[${ts}] [${stream}] ${msg}\n`
+    appendFileSync(getLogPath(), line)
+    enforceRetention()
+  } catch {
+    /* silent — never throw from logging path */
+  }
+}
+
+export const flush = (): void => {
+  // appendFileSync is synchronous — no buffer to flush. Hook left for future async impl.
+  enforceRetention()
+}
+
+export const getRecentLines = (n: number, stream?: LogStream): string[] => {
+  try {
+    const dir = getLogsDir()
+    const files = readdirSync(dir)
+      .filter((name) => name.startsWith(FILE_PREFIX) && name.endsWith(FILE_SUFFIX))
+      .sort()
+    const buffer: string[] = []
+    for (let i = files.length - 1; i >= 0 && buffer.length < n; i--) {
+      const full = join(dir, files[i])
+      try {
+        const lines = readFileSync(full, 'utf8').split('\n').filter(Boolean)
+        for (let j = lines.length - 1; j >= 0 && buffer.length < n; j--) {
+          if (!stream || lines[j].includes(`[${stream}]`)) {
+            buffer.unshift(lines[j])
+          }
+        }
+      } catch {
+        /* ignore broken file */
+      }
+    }
+    return buffer
+  } catch {
+    return []
+  }
+}

--- a/src/main/services/gateway-probes.ts
+++ b/src/main/services/gateway-probes.ts
@@ -1,0 +1,125 @@
+import { spawn } from 'child_process'
+import { platform } from 'os'
+import { getPathEnv } from './path-utils'
+import { WSL_NVM_INIT } from './wsl-utils'
+
+export const GATEWAY_PORT = 18789
+
+// macOS launchd identity for the OpenClaw gateway daemon.
+// Mirrors the value written by onboarder.ts when patching the plist.
+export const LAUNCHD_LABEL = 'ai.openclaw.gateway'
+
+const runShort = (
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+  env?: NodeJS.ProcessEnv
+): Promise<{ code: number | null; stdout: string; stderr: string }> =>
+  new Promise((resolve) => {
+    const child = spawn(cmd, args, { env: env ?? process.env })
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already dead */
+      }
+    }, timeoutMs)
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (d) => (stdout += d.toString()))
+    child.stderr?.on('data', (d) => (stderr += d.toString()))
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ code, stdout, stderr })
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve({ code: null, stdout, stderr })
+    })
+  })
+
+export const probeMacLaunchd = async (): Promise<boolean> => {
+  const uid = process.getuid?.() ?? 0
+  // launchctl print returns multi-line output incl. "state = running"
+  const printResult = await runShort(
+    'launchctl',
+    ['print', `gui/${uid}/${LAUNCHD_LABEL}`],
+    2000,
+    getPathEnv()
+  )
+  if (printResult.code === 0 && /state\s*=\s*running/.test(printResult.stdout)) {
+    return true
+  }
+  // Fallback: launchctl list <label> exits 0 with PID column when running
+  const listResult = await runShort('launchctl', ['list', LAUNCHD_LABEL], 2000, getPathEnv())
+  if (listResult.code === 0) {
+    const pid = listResult.stdout.trim().split(/\s+/)[0]
+    if (pid && /^\d+$/.test(pid)) return true
+  }
+  return false
+}
+
+export const probeMacPort = async (port = GATEWAY_PORT): Promise<boolean> => {
+  const result = await runShort('lsof', ['-i', `:${port}`, '-t'], 2000, getPathEnv())
+  if (result.code !== 0) return false
+  const firstLine = result.stdout.split('\n')[0]?.trim() ?? ''
+  return firstLine.length > 0
+}
+
+export const probeMacAlive = async (port = GATEWAY_PORT): Promise<boolean> => {
+  // Either launchd state OR an actual port listener counts as alive.
+  // launchd "running" without a listener can briefly happen during boot.
+  const [launchd, port_] = await Promise.all([probeMacLaunchd(), probeMacPort(port)])
+  return launchd || port_
+}
+
+const WSL_PROBE_SCRIPT = (port: number): string => {
+  // 18789 in hex = 495D (lowercase). /proc/net/tcp uses uppercase, normalize.
+  const hex = port.toString(16).toUpperCase().padStart(4, '0')
+  return [
+    `(ss -ltn 2>/dev/null | awk '$4 ~ /:${port}$/ {print "OK"; exit 0}')`,
+    `(lsof -i :${port} -t 2>/dev/null | head -n1 | grep -q . && echo OK)`,
+    `(awk '$2 ~ /:${hex}$/ {print "OK"; exit}' /proc/net/tcp /proc/net/tcp6 2>/dev/null)`
+  ].join(' || ')
+}
+
+const runWslShort = (script: string, timeoutMs: number): Promise<string> =>
+  new Promise((resolve) => {
+    const child = spawn('wsl', [
+      '-d',
+      'Ubuntu',
+      '-u',
+      'root',
+      '--',
+      'bash',
+      '-lc',
+      WSL_NVM_INIT + script
+    ])
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already dead */
+      }
+    }, timeoutMs)
+    let stdout = ''
+    child.stdout.on('data', (d) => (stdout += d.toString()))
+    child.on('close', () => {
+      clearTimeout(timer)
+      resolve(stdout)
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve(stdout)
+    })
+  })
+
+export const probeWslAlive = async (port = GATEWAY_PORT): Promise<boolean> => {
+  const out = await runWslShort(WSL_PROBE_SCRIPT(port), 3000)
+  return /\bOK\b/.test(out)
+}
+
+export const probeAlive = async (): Promise<boolean> => {
+  if (platform() === 'win32') return probeWslAlive()
+  return probeMacAlive()
+}

--- a/src/main/services/gateway-supervisor.ts
+++ b/src/main/services/gateway-supervisor.ts
@@ -1,0 +1,392 @@
+import { spawn, ChildProcess } from 'child_process'
+import { EventEmitter } from 'events'
+import { platform } from 'os'
+import { getPathEnv, findBin } from './path-utils'
+import { WSL_NVM_INIT } from './wsl-utils'
+import { probeAlive } from './gateway-probes'
+import * as logRotator from './gateway-log-rotator'
+import { t } from '../../shared/i18n/main'
+
+export type GatewayStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'failed'
+
+export interface ExitInfo {
+  code: number | null
+  stderrTail: string
+  ts: number
+}
+
+export interface StartResult {
+  status: 'started' | 'error'
+  error?: string
+}
+
+interface SupervisorEvents {
+  log: (msg: string) => void
+  died: (info: ExitInfo) => void
+  started: () => void
+  failed: (error: string) => void
+  'status-changed': (status: GatewayStatus) => void
+}
+
+const HEALTH_LOOP_MS = 5000
+const BOOT_PROBE_INTERVAL_MS = 500
+const BOOT_PROBE_MAX_MS = 15000
+const STDERR_TAIL_LINES = 200
+
+const isWindows = platform() === 'win32'
+
+class GatewaySupervisor extends EventEmitter {
+  private status: GatewayStatus = 'idle'
+  private wslChild: ChildProcess | null = null
+  private wslStderrBuffer: string[] = []
+  private healthTimer: NodeJS.Timeout | null = null
+  private lastExit: ExitInfo | null = null
+  private starting: Promise<StartResult> | null = null
+  private stopping: Promise<void> | null = null
+
+  override on<K extends keyof SupervisorEvents>(event: K, listener: SupervisorEvents[K]): this {
+    return super.on(event, listener)
+  }
+
+  override emit<K extends keyof SupervisorEvents>(
+    event: K,
+    ...args: Parameters<SupervisorEvents[K]>
+  ): boolean {
+    return super.emit(event, ...args)
+  }
+
+  getStatus(): GatewayStatus {
+    return this.status
+  }
+
+  lastExitInfo(): ExitInfo | null {
+    return this.lastExit
+  }
+
+  async isAlive(): Promise<boolean> {
+    return probeAlive()
+  }
+
+  async start(): Promise<StartResult> {
+    if (this.starting) return this.starting
+    this.starting = this.startInternal().finally(() => {
+      this.starting = null
+    })
+    return this.starting
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopping) return this.stopping
+    this.stopping = this.stopInternal().finally(() => {
+      this.stopping = null
+    })
+    return this.stopping
+  }
+
+  async restart(): Promise<StartResult> {
+    try {
+      await this.stop()
+    } catch {
+      /* already stopped */
+    }
+    await this.waitUntilGone(5000)
+    return this.start()
+  }
+
+  startHealthLoop(): void {
+    if (this.healthTimer) return
+    this.healthTimer = setInterval(() => {
+      void this.healthTick()
+    }, HEALTH_LOOP_MS)
+  }
+
+  stopHealthLoop(): void {
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer)
+      this.healthTimer = null
+    }
+  }
+
+  // ---------- internals ----------
+
+  private setStatus(next: GatewayStatus): void {
+    if (this.status === next) return
+    this.status = next
+    this.emit('status-changed', next)
+  }
+
+  private logBoth(msg: string, stream: logRotator.LogStream = 'meta'): void {
+    if (!msg) return
+    logRotator.writeLine(stream, msg)
+    this.emit('log', msg)
+  }
+
+  private async startInternal(): Promise<StartResult> {
+    if (this.status === 'running' && (await this.isAlive())) {
+      return { status: 'started' }
+    }
+    this.setStatus('starting')
+    try {
+      const result = isWindows ? await this.startWsl() : await this.startMac()
+      if (result.status === 'started') {
+        const ok = await this.waitUntilAlive()
+        if (!ok) {
+          this.setStatus('failed')
+          this.emit('failed', 'gateway did not become alive within 15s')
+          return { status: 'error', error: 'boot probe timeout' }
+        }
+        this.setStatus('running')
+        this.emit('started')
+        this.startHealthLoop()
+      } else {
+        this.setStatus('failed')
+        this.emit('failed', result.error ?? 'unknown error')
+      }
+      return result
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      this.setStatus('failed')
+      this.emit('failed', msg)
+      return { status: 'error', error: msg }
+    }
+  }
+
+  private async stopInternal(): Promise<void> {
+    this.stopHealthLoop()
+    if (isWindows) {
+      await this.stopWsl()
+    } else {
+      await this.stopMac()
+    }
+    this.setStatus('idle')
+  }
+
+  private async waitUntilAlive(): Promise<boolean> {
+    const deadline = Date.now() + BOOT_PROBE_MAX_MS
+    while (Date.now() < deadline) {
+      if (await this.isAlive()) return true
+      await sleep(BOOT_PROBE_INTERVAL_MS)
+    }
+    return false
+  }
+
+  private async waitUntilGone(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (!(await this.isAlive())) return
+      await sleep(500)
+    }
+  }
+
+  private async healthTick(): Promise<void> {
+    if (this.starting || this.stopping) return
+    if (this.status !== 'running') return
+    const alive = await this.isAlive()
+    if (alive) return
+    // Transition: running → stopped, emit died
+    this.setStatus('stopped')
+    this.lastExit = {
+      code: null,
+      stderrTail: this.wslStderrBuffer.slice(-STDERR_TAIL_LINES).join('\n'),
+      ts: Date.now()
+    }
+    this.logBoth(t('gateway.processExit', { code: 'unknown' }))
+    this.emit('died', this.lastExit)
+    this.stopHealthLoop()
+  }
+
+  // ---------- macOS adapter ----------
+
+  private async startMac(): Promise<StartResult> {
+    try {
+      await this.runOpenclawCli(['gateway', 'start'])
+      await this.runOpenclawCli(['doctor', '--fix']).catch(() => undefined)
+      return { status: 'started' }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const isServiceMissing =
+        msg.includes('not loaded') || msg.includes('not installed') || msg.includes('bootstrap')
+      if (!isServiceMissing) return { status: 'error', error: msg }
+      // Auto-install launchd service then retry
+      this.logBoth(t('gateway.notInstalledRetry'))
+      try {
+        await this.runOpenclawCli(['gateway', 'install'])
+        await this.runOpenclawCli(['gateway', 'start'])
+        await this.runOpenclawCli(['doctor', '--fix']).catch(() => undefined)
+        return { status: 'started' }
+      } catch (retryErr) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr)
+        return { status: 'error', error: retryMsg }
+      }
+    }
+  }
+
+  private async stopMac(): Promise<void> {
+    try {
+      await this.runOpenclawCli(['gateway', 'stop'])
+    } catch {
+      /* already stopped */
+    }
+  }
+
+  private runOpenclawCli(args: string[]): Promise<string> {
+    const openclaw = findBin('openclaw')
+    return new Promise((resolve, reject) => {
+      const child = spawn(openclaw, args, { env: getPathEnv() })
+      let stdout = ''
+      let stderr = ''
+      child.stdout.on('data', (d) => {
+        const msg = d.toString()
+        stdout += msg
+        const trimmed = msg.trim()
+        if (trimmed) this.logBoth(trimmed, 'stdout')
+      })
+      child.stderr.on('data', (d) => {
+        const msg = d.toString()
+        stderr += msg
+        const trimmed = msg.trim()
+        if (trimmed) this.logBoth(trimmed, 'stderr')
+      })
+      child.on('close', (code) => {
+        if (code === 0) resolve(stdout.trim())
+        else reject(new Error(stderr.trim() || `exit code ${code}`))
+      })
+      child.on('error', reject)
+    })
+  }
+
+  // ---------- WSL adapter ----------
+
+  private async startWsl(): Promise<StartResult> {
+    if (this.wslChild) {
+      try {
+        this.wslChild.kill()
+      } catch {
+        /* ignore */
+      }
+      this.wslChild = null
+    }
+    await this.killWslOpenclaw()
+    await sleep(1000)
+    this.wslStderrBuffer = []
+
+    return new Promise<StartResult>((resolve) => {
+      const child = spawn(
+        'wsl',
+        [
+          '-d',
+          'Ubuntu',
+          '-u',
+          'root',
+          '--',
+          'bash',
+          '-lc',
+          `${WSL_NVM_INIT}NODE_OPTIONS=--dns-result-order=ipv4first openclaw gateway run`
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      )
+
+      this.wslChild = child
+      let resolved = false
+
+      child.stdout.on('data', (d) => {
+        const msg = d.toString().trim()
+        if (msg) this.logBoth(msg, 'stdout')
+        if (!resolved) {
+          resolved = true
+          resolve({ status: 'started' })
+        }
+      })
+
+      child.stderr.on('data', (d) => {
+        const msg = d.toString().trim()
+        if (msg) {
+          this.logBoth(msg, 'stderr')
+          this.wslStderrBuffer.push(msg)
+          if (this.wslStderrBuffer.length > STDERR_TAIL_LINES * 2) {
+            this.wslStderrBuffer = this.wslStderrBuffer.slice(-STDERR_TAIL_LINES)
+          }
+        }
+        if (!resolved) {
+          resolved = true
+          resolve({ status: 'started' })
+        }
+      })
+
+      child.on('close', (code) => {
+        const wasOurChild = this.wslChild === child
+        if (wasOurChild) this.wslChild = null
+        const tail = this.wslStderrBuffer.slice(-STDERR_TAIL_LINES).join('\n')
+        this.lastExit = { code, stderrTail: tail, ts: Date.now() }
+        this.logBoth(t('gateway.processExit', { code: code ?? 'unknown' }))
+        if (code !== 0 && tail) {
+          this.logBoth(`${t('gateway.errorDetail')}\n${tail}`)
+        }
+        if (!resolved) {
+          resolved = true
+          resolve(
+            code === 0
+              ? { status: 'started' }
+              : { status: 'error', error: tail || `exit code ${code}` }
+          )
+        }
+        if (wasOurChild && this.status === 'running') {
+          this.setStatus('stopped')
+          this.emit('died', this.lastExit)
+          this.stopHealthLoop()
+        }
+      })
+
+      child.on('error', (err) => {
+        if (this.wslChild === child) this.wslChild = null
+        this.logBoth(t('gateway.error', { message: err.message }))
+        if (!resolved) {
+          resolved = true
+          resolve({ status: 'error', error: err.message })
+        }
+      })
+    })
+  }
+
+  private async stopWsl(): Promise<void> {
+    if (this.wslChild) {
+      try {
+        this.wslChild.kill()
+      } catch {
+        /* ignore */
+      }
+      this.wslChild = null
+    }
+    await this.killWslOpenclaw()
+    await sleep(1000)
+  }
+
+  private killWslOpenclaw(): Promise<void> {
+    return new Promise((resolve) => {
+      const child = spawn('wsl', [
+        '-d',
+        'Ubuntu',
+        '-u',
+        'root',
+        '--',
+        'pkill',
+        '-9',
+        '-f',
+        'openclaw'
+      ])
+      child.on('close', () => resolve())
+      child.on('error', () => resolve())
+    })
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+let supervisor: GatewaySupervisor | null = null
+
+export const getSupervisor = (): GatewaySupervisor => {
+  if (!supervisor) supervisor = new GatewaySupervisor()
+  return supervisor
+}
+
+export type { GatewaySupervisor }

--- a/src/main/services/gateway.ts
+++ b/src/main/services/gateway.ts
@@ -1,278 +1,41 @@
-import { spawn, ChildProcess } from 'child_process'
-import { platform } from 'os'
-import { getPathEnv, findBin } from './path-utils'
-import { WSL_NVM_INIT } from './wsl-utils'
-import { checkPort } from './troubleshooter'
-import { t } from '../../shared/i18n/main'
+import { getSupervisor, type StartResult } from './gateway-supervisor'
 
-export interface GatewayResult {
-  status: string
-  error?: string
-}
+export type GatewayResult = StartResult
 
-// Windows WSL: keep gateway as a foreground process
-let wslGatewayProcess: ChildProcess | null = null
-
-// Gateway log callback (set from ipc-handlers)
-let logCallback: ((msg: string) => void) | null = null
+let activeLogListener: ((msg: string) => void) | null = null
 
 export const setGatewayLogCallback = (cb: ((msg: string) => void) | null): void => {
-  logCallback = cb
-}
-
-const emitLog = (msg: string): void => {
-  logCallback?.(msg)
-}
-
-const runGateway = (args: string[]): Promise<string> => {
-  const openclaw = findBin('openclaw')
-  const fullArgs = ['gateway', ...args]
-
-  return new Promise((resolve, reject) => {
-    const child = spawn(openclaw, fullArgs, {
-      env: getPathEnv()
-    })
-
-    let stdout = ''
-    let stderr = ''
-
-    child.stdout.on('data', (d) => (stdout += d.toString()))
-    child.stderr.on('data', (d) => (stderr += d.toString()))
-    child.on('close', (code) => {
-      if (code === 0) resolve(stdout.trim())
-      else reject(new Error(stderr || `exit code ${code}`))
-    })
-    child.on('error', reject)
-  })
-}
-
-const startGatewayWsl = async (): Promise<GatewayResult> => {
-  if (wslGatewayProcess) {
-    wslGatewayProcess.kill()
-    wslGatewayProcess = null
+  const supervisor = getSupervisor()
+  if (activeLogListener) {
+    supervisor.off('log', activeLogListener)
+    activeLogListener = null
   }
-  await killWslGateway()
-  await new Promise((r) => setTimeout(r, 1000))
-
-  return new Promise((resolve) => {
-    const child = spawn(
-      'wsl',
-      [
-        '-d',
-        'Ubuntu',
-        '-u',
-        'root',
-        '--',
-        'bash',
-        '-lc',
-        `${WSL_NVM_INIT}NODE_OPTIONS=--dns-result-order=ipv4first openclaw gateway run`
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] }
-    )
-
-    wslGatewayProcess = child
-
-    let resolved = false
-    let stderrBuffer = ''
-
-    child.stdout.on('data', (d) => {
-      const msg = d.toString().trim()
-      if (msg) emitLog(msg)
-      if (!resolved) {
-        resolved = true
-        resolve({ status: 'started' })
-      }
-    })
-
-    child.stderr.on('data', (d) => {
-      const msg = d.toString().trim()
-      if (msg) {
-        emitLog(msg)
-        stderrBuffer += msg + '\n'
-      }
-      if (!resolved) {
-        resolved = true
-        resolve({ status: 'started' })
-      }
-    })
-
-    child.on('close', (code) => {
-      wslGatewayProcess = null
-      emitLog(t('gateway.processExit', { code }))
-      if (code !== 0 && stderrBuffer) {
-        emitLog(`${t('gateway.errorDetail')}\n${stderrBuffer.trim()}`)
-      }
-      if (!resolved) {
-        resolved = true
-        if (code !== 0) {
-          resolve({ status: 'stopped', error: stderrBuffer.trim() || `exit code ${code}` })
-        } else {
-          resolve({ status: 'stopped' })
-        }
-      }
-    })
-
-    child.on('error', (err) => {
-      wslGatewayProcess = null
-      emitLog(t('gateway.error', { message: err.message }))
-      if (!resolved) {
-        resolved = true
-        resolve({ status: 'error', error: err.message })
-      }
-    })
-
-    setTimeout(() => {
-      if (!resolved) {
-        resolved = true
-        resolve({ status: 'started' })
-      }
-    }, 3000)
-  })
+  if (cb) {
+    activeLogListener = cb
+    supervisor.on('log', cb)
+  }
 }
 
-const killWslGateway = (): Promise<void> =>
-  new Promise((resolve) => {
-    const child = spawn('wsl', [
-      '-d',
-      'Ubuntu',
-      '-u',
-      'root',
-      '--',
-      'pkill',
-      '-9',
-      '-f',
-      'openclaw'
-    ])
-    child.on('close', () => resolve())
-    child.on('error', () => resolve())
-  })
-
-const stopGatewayWsl = async (): Promise<string> => {
-  if (wslGatewayProcess) {
-    wslGatewayProcess.kill()
-    wslGatewayProcess = null
+export const waitUntilStopped = async (timeoutMs = 5000): Promise<void> => {
+  const supervisor = getSupervisor()
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!(await supervisor.isAlive())) return
+    await new Promise((r) => setTimeout(r, 500))
   }
-  await killWslGateway()
-  await new Promise((r) => setTimeout(r, 1000))
+}
+
+export const startGateway = (): Promise<GatewayResult> => getSupervisor().start()
+
+export const stopGateway = async (): Promise<string> => {
+  await getSupervisor().stop()
   return 'stopped'
 }
 
-const runDoctorFix = (): Promise<void> =>
-  new Promise((resolve) => {
-    const isWin = platform() === 'win32'
-    let cmd: string
-    let args: string[]
-
-    if (isWin) {
-      cmd = 'wsl'
-      args = [
-        '-d',
-        'Ubuntu',
-        '-u',
-        'root',
-        '--',
-        'bash',
-        '-lc',
-        `${WSL_NVM_INIT}openclaw doctor --fix`
-      ]
-    } else {
-      cmd = findBin('openclaw')
-      args = ['doctor', '--fix']
-    }
-
-    const child = spawn(cmd, args, {
-      env: isWin ? process.env : getPathEnv()
-    })
-    child.stdout.on('data', (d) => {
-      const msg = d.toString().trim()
-      if (msg) emitLog(msg)
-    })
-    child.stderr.on('data', (d) => {
-      const msg = d.toString().trim()
-      if (msg) emitLog(msg)
-    })
-    child.on('close', () => resolve())
-    child.on('error', () => resolve())
-  })
-
-const forceKillGateway = (): Promise<void> =>
-  new Promise((resolve) => {
-    const child = spawn('pkill', ['-f', 'openclaw gateway'])
-    child.on('close', () => resolve())
-    child.on('error', () => resolve())
-  })
-
-export const waitUntilStopped = async (timeoutMs = 5000): Promise<void> => {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const { inUse } = await checkPort()
-    if (!inUse) return
-    await new Promise((r) => setTimeout(r, 500))
-  }
-  if (platform() !== 'win32') {
-    await forceKillGateway()
-    await new Promise((r) => setTimeout(r, 1000))
-  }
-}
-
-export const startGateway = async (): Promise<GatewayResult> => {
-  const isWin = platform() === 'win32'
-  if (isWin) {
-    const result = await startGatewayWsl()
-    if (result.status === 'started') {
-      await runDoctorFix()
-    }
-    return result
-  }
-
-  try {
-    await runGateway(['start'])
-    await runDoctorFix()
-    return { status: 'started' }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    const isServiceMissing =
-      msg.includes('not loaded') || msg.includes('not installed') || msg.includes('bootstrap')
-    if (!isServiceMissing) return { status: 'error', error: msg }
-
-    // Auto-install and retry when launchd service is not installed
-    emitLog(t('gateway.notInstalledRetry'))
-    try {
-      await runGateway(['install'])
-      await runGateway(['start'])
-      await runDoctorFix()
-      return { status: 'started' }
-    } catch (retryErr) {
-      const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr)
-      return { status: 'error', error: retryMsg }
-    }
-  }
-}
-
-export const stopGateway = (): Promise<string> => {
-  const isWin = platform() === 'win32'
-  if (isWin) return stopGatewayWsl()
-  return runGateway(['stop'])
-}
-
-export const restartGateway = async (): Promise<GatewayResult> => {
-  try {
-    await stopGateway()
-  } catch {
-    /* already stopped */
-  }
-  await waitUntilStopped()
-  return startGateway()
-}
+export const restartGateway = (): Promise<GatewayResult> => getSupervisor().restart()
 
 export const getGatewayStatus = async (): Promise<'running' | 'stopped'> => {
-  if (platform() === 'win32') {
-    return wslGatewayProcess && !wslGatewayProcess.killed ? 'running' : 'stopped'
-  }
-  try {
-    const output = await runGateway(['status'])
-    return output.toLowerCase().includes('running') ? 'running' : 'stopped'
-  } catch {
-    return 'stopped'
-  }
+  const supervisor = getSupervisor()
+  if (await supervisor.isAlive()) return 'running'
+  return 'stopped'
 }

--- a/src/main/services/onboarder.ts
+++ b/src/main/services/onboarder.ts
@@ -4,9 +4,26 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from '
 import { platform, homedir } from 'os'
 import { join } from 'path'
 import https from 'https'
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { runInWsl, readWslFile, writeWslFile, WSL_NVM_INIT } from './wsl-utils'
 import { t } from '../../shared/i18n/main'
+
+const launchdLogPaths = (): { logsDir: string; stdoutPath: string; stderrPath: string } => {
+  const logsDir = join(app.getPath('userData'), 'logs')
+  return {
+    logsDir,
+    stdoutPath: join(logsDir, 'launchd-gateway.out.log'),
+    stderrPath: join(logsDir, 'launchd-gateway.err.log')
+  }
+}
+
+const ensureDir = (dir: string): void => {
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  } catch {
+    /* best effort — launchd will surface errors if path is unwritable */
+  }
+}
 
 interface OnboardConfig {
   provider: 'anthropic' | 'google' | 'openai' | 'minimax' | 'glm' | 'deepseek' | 'ollama'
@@ -114,7 +131,7 @@ const createRunCmd = (): ((
     })
 }
 
-const wslKillOpenclaw = (): Promise<void> =>
+export const wslKillOpenclaw = (): Promise<void> =>
   new Promise((resolve) => {
     const child = spawn('wsl', [
       '-d',
@@ -130,6 +147,50 @@ const wslKillOpenclaw = (): Promise<void> =>
     child.on('close', () => resolve())
     child.on('error', () => resolve())
   })
+
+// Patch launchd plist to capture daemon stdout/stderr to disk so EasyClaw
+// can show recent crash output to the user. Idempotent — bails when keys
+// are already present. Run once at app startup for upgraders.
+export const migrateGatewayPlist = async (): Promise<void> => {
+  if (platform() !== 'darwin') return
+  const plistPath = join(homedir(), 'Library', 'LaunchAgents', 'ai.openclaw.gateway.plist')
+  if (!existsSync(plistPath)) return
+  let xml: string
+  try {
+    xml = readFileSync(plistPath, 'utf-8')
+  } catch {
+    return
+  }
+  if (xml.includes('StandardOutPath')) return
+
+  const { logsDir, stdoutPath, stderrPath } = launchdLogPaths()
+  ensureDir(logsDir)
+
+  const insertion =
+    `<key>StandardOutPath</key>\n  <string>${stdoutPath}</string>\n` +
+    `  <key>StandardErrorPath</key>\n  <string>${stderrPath}</string>\n  `
+  const patched = xml.replace(/<\/dict>\s*<\/plist>/, `${insertion}</dict>\n</plist>`)
+  if (patched === xml) return
+
+  try {
+    writeFileSync(plistPath, patched)
+  } catch {
+    return
+  }
+
+  const uid = process.getuid?.() ?? ''
+  await new Promise<void>((resolve) => {
+    const child = spawn('launchctl', ['bootout', `gui/${uid}/ai.openclaw.gateway`])
+    child.on('close', () => resolve())
+    child.on('error', () => resolve())
+  })
+  await new Promise((r) => setTimeout(r, 500))
+  await new Promise<void>((resolve) => {
+    const child = spawn('launchctl', ['bootstrap', `gui/${uid}`, plistPath])
+    child.on('close', () => resolve())
+    child.on('error', () => resolve())
+  })
+}
 
 export const runOnboard = async (
   win: BrowserWindow,
@@ -384,6 +445,14 @@ export const runOnboard = async (
           '</dict>\n  </dict>',
           `<key>NODE_OPTIONS</key>\n    <string>${nodeOpt}</string>\n    </dict>\n  </dict>`
         )
+      }
+      if (!xml.includes('StandardOutPath')) {
+        const { logsDir, stdoutPath, stderrPath } = launchdLogPaths()
+        ensureDir(logsDir)
+        const insertion =
+          `<key>StandardOutPath</key>\n  <string>${stdoutPath}</string>\n` +
+          `  <key>StandardErrorPath</key>\n  <string>${stderrPath}</string>\n  `
+        xml = xml.replace(/<\/dict>\s*<\/plist>/, `${insertion}</dict>\n</plist>`)
       }
       writeFileSync(plistAfter, xml)
     }


### PR DESCRIPTION
## Summary

PR-1 of two for the **v1.3.39 stability release** addressing the bug
multiple users reported in the Kakao group chat: the gateway keeps
shutting down (often right after a Telegram command), and EasyClaw
silently leaves them with an unresponsive bot.

This PR is the **safety core** — it restructures gateway lifecycle
internals without changing user-visible behavior. Auto-restart, the
3-state tray, and the diagnostic copy modal land in PR-2.

- **Supervisor abstraction** — new `gateway-supervisor.ts` owns lifecycle
  via an `EventEmitter` singleton with macOS-launchd and WSL adapters.
  Existing IPC / tray / index call sites keep working through a thin
  `gateway.ts` wrapper.
- **Real liveness probes** — new `gateway-probes.ts` replaces the brittle
  `wsl.exe child .killed` check (which kept saying "running" while the
  WSL-internal openclaw was already dead). macOS uses `launchctl print`
  + `lsof :18789`; WSL runs `ss → lsof → /proc/net/tcp` inside the distro.
- **Persistent gateway log** — new `gateway-log-rotator.ts` writes daemon
  stdout/stderr to `userData/logs/gateway-YYYY-MM-DD.log` with 7-day
  retention + 50 MB cap. Combined with the new `StandardOutPath` /
  `StandardErrorPath` launchd plist patch, future PR-2 diagnostics will
  always have the last crash output on disk.
- **Quit cleanup** — `before-quit` now stops the supervisor + flushes the
  log before exit with a 3 s cap, fixing orphaned WSL daemons that caused
  port-already-in-use on next launch.
- **Plist migration** — `migrateGatewayPlist()` runs once at startup so
  existing v1.3.38 users upgrade to capturing daemon stdout/stderr without
  needing to re-onboard.

## Test plan

- [x] `npm run typecheck` — passes (node + web)
- [x] `npm run lint` — no new warnings (1 pre-existing prettier warning in
      `LobsterLogo.tsx` unchanged)
- [ ] macOS smoke: open EasyClaw, verify Gateway shows "running", then
      `pkill -9 -f openclaw-gateway`. Tray should flip to "stopped" within
      ~10s. Manual restart via tray menu should bring it back.
- [ ] macOS plist migration: with an existing install, launch EasyClaw
      and verify `~/Library/LaunchAgents/ai.openclaw.gateway.plist`
      contains `StandardOutPath` after first run, and that
      `userData/logs/launchd-gateway.{out,err}.log` start populating.
- [ ] Windows WSL smoke: open EasyClaw, then in another terminal
      `wsl -d Ubuntu -u root -- pkill -9 -f openclaw`. Tray should flip
      to "stopped" (this is the regression case — previously the tray
      stayed at "running" because `wsl.exe`'s `.killed` flag was false).
- [ ] Quit cleanup: trigger Quit from tray, then verify
      `wsl --list --running` does not show openclaw on Windows, and
      `pgrep -f openclaw-gateway` returns nothing on macOS.

PR-2 (auto-restart, 3-state tray, diagnostic modal, switchProvider boot
order fix) follows immediately.