### PR TITLE
feat: auto-restart + diagnostic + UX 3-state (PR-2 of v1.3.39)

### DIFF
--- a/docs/QA-1.3.39.md
+++ b/docs/QA-1.3.39.md
@@ -60,10 +60,13 @@ on both macOS and Windows (WSL) before tagging the release.
 - [ ] Create a 60 MB fake log to exceed cap — oldest files trimmed first
 
 ## S7 — PII masking
-- [ ] Trigger a crash with a fake bot token in the daemon stderr
-      (e.g., set `TELEGRAM_BOT_TOKEN=bot1234567890:AAFAKEkeyABCDEFGHIJKLMNOPQRSTUVWXYZ`)
-- [ ] Open DiagnosticModal — token shown as `bot1234567890:****MASKED****`
-- [ ] Same check for `sk-...`, `sk-ant-...`, `AIza...` patterns
+- [ ] Trigger a crash with a placeholder bot token in the daemon stderr
+      (set `TELEGRAM_BOT_TOKEN=bot<DIGITS>:<35+_TOKEN_CHARS>` shaped to match
+      the regex `bot([0-9]+):[A-Za-z0-9_-]{30,}`)
+- [ ] Open DiagnosticModal — the digits part is preserved while the token
+      part is shown as `****MASKED****`
+- [ ] Same check for `sk-...`, `sk-ant-...`, `AIza...` patterns (use any
+      string matching the shape; do not paste a real key)
 
 ## Sign-off
 - [ ] macOS results captured in screenshots / paste of diagnostic text

--- a/docs/QA-1.3.39.md
+++ b/docs/QA-1.3.39.md
@@ -1,0 +1,72 @@
+# QA Checklist — v1.3.39 Gateway Stability
+
+This release addresses the recurring "Gateway keeps shutting down" issue
+reported by multiple users in the Kakao group chat. Run every scenario
+on both macOS and Windows (WSL) before tagging the release.
+
+## Setup
+- [ ] Build a fresh installer from `feat/gateway-supervisor` + `feat/gateway-diagnostic`
+- [ ] Install over a v1.3.38 install (upgrade path) on both OSes
+- [ ] Verify `~/Library/Application Support/easy-claw/logs/` exists after first
+      launch (macOS) or `%APPDATA%/easy-claw/logs/` (Windows)
+
+## S1 — Force-kill triggers auto-restart
+- [ ] **macOS**: `pkill -9 -f openclaw-gateway`
+  - Tray flips to "Gateway Restarting..." within ~5s
+  - Within ~10s, tray returns to "Gateway Running"
+  - `logs/gateway-YYYY-MM-DD.log` shows the death + restart attempt
+  - Notification "Gateway just exited — auto-restarting now" appears
+- [ ] **Windows WSL**: `wsl -d Ubuntu -u root -- pkill -9 -f openclaw`
+  - Same expectations as above
+  - **Regression check**: previously the tray stayed at "running" because
+    `wsl.exe`'s `.killed` flag was false. Confirm new probe correctly
+    detects the inner process death.
+
+## S2 — Crash loop hits give-up + diagnostic modal
+- [ ] Repeatedly kill the gateway 5 times within 60 s using the S1 commands
+- [ ] After the 5th attempt:
+  - Tray label changes to "Gateway Failed (max restarts reached)"
+  - DoneStep shows the red "Gateway 재시작 실패" banner
+  - DiagnosticModal opens automatically
+  - Notification "Gateway failed to restart 5 times" fires (bypasses throttle)
+- [ ] Click "Copy to Clipboard" — diagnostic text is on the clipboard
+- [ ] Click "Open Kakao Group Chat" — opens https://open.kakao.com/o/gbBkPehi
+- [ ] Click "Retry" — gateway starts again, banner clears
+- [ ] Wait 60 minutes, kill again — auto-restart resumes (window slid)
+
+## S3 — onboard finishes with gateway already alive
+- [ ] Wipe install (`uninstall:openclaw` + remove `~/.openclaw/`)
+- [ ] Run through onboarding from scratch with a Telegram bot
+- [ ] When DoneStep appears, `electronAPI.gateway.status()` returns
+      `running` immediately (no 30 s polling delay)
+- [ ] `userData/logs/launchd-gateway.{out,err}.log` (macOS) starts
+      receiving daemon output
+
+## S4 — switchProvider boots the daemon exactly once
+- [ ] In DoneStep, click "변경" → switch from current provider to another
+- [ ] Inspect `gateway-restart-history.json` and the daemon log
+- [ ] Exactly **one** `kind=manual success=true` entry appears (was 2 in v1.3.38)
+
+## S5 — App quit cleans up
+- [ ] macOS: tray menu → Quit
+  - `pgrep -f openclaw-gateway` returns empty (or launchd-managed PID is gone)
+  - Log file ends with `[meta] app quit — cleanup done`
+- [ ] Windows: tray menu → Quit
+  - `wsl --list --running` does not show openclaw running
+
+## S6 — Log rotation
+- [ ] Generate a few days of logs (or fast-forward the system clock by 8 days)
+- [ ] Re-launch EasyClaw — files older than 7 days deleted from `logs/`
+- [ ] Create a 60 MB fake log to exceed cap — oldest files trimmed first
+
+## S7 — PII masking
+- [ ] Trigger a crash with a fake bot token in the daemon stderr
+      (e.g., set `TELEGRAM_BOT_TOKEN=bot1234567890:AAFAKEkeyABCDEFGHIJKLMNOPQRSTUVWXYZ`)
+- [ ] Open DiagnosticModal — token shown as `bot1234567890:****MASKED****`
+- [ ] Same check for `sk-...`, `sk-ant-...`, `AIza...` patterns
+
+## Sign-off
+- [ ] macOS results captured in screenshots / paste of diagnostic text
+- [ ] Windows results captured the same way
+- [ ] CHANGELOG entry drafted
+- [ ] Ready to `npm run release` (patch bump from 1.3.38 → 1.3.39)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-claw",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "description": "One-click installer for OpenClaw AI agent",
   "license": "MIT",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-claw",
-  "version": "1.3.39",
+  "version": "1.3.38",
   "description": "One-click installer for OpenClaw AI agent",
   "license": "MIT",
   "main": "./out/main/index.js",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, app } from 'electron'
+import { ipcMain, BrowserWindow, app, clipboard } from 'electron'
 import { spawn } from 'child_process'
 import { platform } from 'os'
 import { join } from 'path'
@@ -22,6 +22,8 @@ import {
   getGatewayStatus,
   setGatewayLogCallback
 } from './services/gateway'
+import { getSupervisor } from './services/gateway-supervisor'
+import { collect as collectDiagnostic } from './services/diagnostic-collector'
 import { checkWslState } from './services/wsl-utils'
 import { checkForUpdates, downloadUpdate, installUpdate } from './services/updater'
 import { uninstallOpenClaw } from './services/uninstaller'
@@ -180,6 +182,11 @@ export const registerIpcHandlers = (getWin: () => BrowserWindow | null): void =>
     ) => {
       try {
         const result = await runOnboard(win(), config)
+        // Boot the gateway through the supervisor so DoneStep sees alive
+        // immediately instead of relying on its 30 s polling fallback.
+        await getSupervisor()
+          .start('manual')
+          .catch(() => undefined)
         return { success: true, botUsername: result.botUsername }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
@@ -226,7 +233,10 @@ export const registerIpcHandlers = (getWin: () => BrowserWindow | null): void =>
     ) => {
       try {
         await switchProvider(win(), config)
-        await restartGateway()
+        // switchProvider already kills the daemon and (on macOS) bootstraps
+        // a fresh one. Drive the supervisor lifecycle here so the renderer
+        // observes a single boot transition instead of a stop/start race.
+        await getSupervisor().start('manual')
         return { success: true }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
@@ -279,6 +289,45 @@ export const registerIpcHandlers = (getWin: () => BrowserWindow | null): void =>
   })
 
   ipcMain.handle('gateway:status', () => getGatewayStatus())
+
+  // Push richer supervisor events to the renderer so DoneStep + tray can
+  // distinguish 'restarting' from 'failed' / 'gave_up' without polling.
+  const supervisor = getSupervisor()
+  const broadcast = (event: string, payload?: unknown): void => {
+    try {
+      win().webContents.send(event, payload)
+    } catch {
+      /* window destroyed */
+    }
+  }
+  supervisor.on('status-changed', (status) => broadcast('gateway:status-changed', { status }))
+  supervisor.on('restarting', (payload) => broadcast('gateway:restarting', payload))
+  supervisor.on('restarted', () => broadcast('gateway:restarted'))
+  supervisor.on('gave_up', (payload) => broadcast('gateway:gave-up', payload))
+  supervisor.on('died', (info) => broadcast('gateway:died', info))
+
+  // Diagnostic — collects stderr / stdout / restart history / platform info
+  // into a single PII-masked text block the user can paste into the Kakao
+  // group chat.
+  ipcMain.handle('diagnostic:collect', async () => {
+    try {
+      return await collectDiagnostic()
+    } catch (e) {
+      return {
+        timestamp: Date.now(),
+        text: `<diagnostic collector failed: ${e instanceof Error ? e.message : String(e)}>`
+      }
+    }
+  })
+
+  ipcMain.handle('diagnostic:copy', (_e, text: string) => {
+    try {
+      clipboard.writeText(text)
+      return { success: true }
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : String(e) }
+    }
+  })
 
   ipcMain.handle('troubleshoot:check-port', () => checkPort())
   ipcMain.handle('troubleshoot:doctor-fix', () => runDoctorFix(win()))

--- a/src/main/services/diagnostic-collector.ts
+++ b/src/main/services/diagnostic-collector.ts
@@ -1,0 +1,218 @@
+import { app } from 'electron'
+import { spawn } from 'child_process'
+import { platform, arch, release } from 'os'
+import { homedir } from 'os'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { getRecentLines } from './gateway-log-rotator'
+import { getRecentEntries } from './gateway-restart-history'
+import { getSupervisor } from './gateway-supervisor'
+import { GATEWAY_PORT, LAUNCHD_LABEL } from './gateway-probes'
+import { checkPort } from './troubleshooter'
+import { getPathEnv } from './path-utils'
+
+export interface DiagnosticReport {
+  timestamp: number
+  text: string
+}
+
+const SUB_PROBE_TIMEOUT_MS = 3000
+const TOTAL_BUDGET_MS = 10_000
+
+const PII_PATTERNS: Array<[RegExp, string]> = [
+  // Telegram bot tokens: bot1234567890:AAH...
+  [/(bot\d+:)[A-Za-z0-9_-]{30,}/g, '$1****MASKED****'],
+  // OpenAI / Anthropic / Generic sk- API keys
+  [/sk-[A-Za-z0-9_-]{20,}/g, 'sk-****MASKED****'],
+  // Google API keys
+  [/AIza[A-Za-z0-9_-]{30,}/g, 'AIza****MASKED****'],
+  // Anthropic-style sk-ant-api03-...
+  [/sk-ant-[A-Za-z0-9_-]{20,}/g, 'sk-ant-****MASKED****']
+]
+
+const maskPii = (text: string): string => {
+  let masked = text
+  for (const [pattern, replacement] of PII_PATTERNS) {
+    masked = masked.replace(pattern, replacement)
+  }
+  return masked
+}
+
+const runShort = (
+  cmd: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv
+): Promise<{ stdout: string; stderr: string; code: number | null }> =>
+  new Promise((resolve) => {
+    const child = spawn(cmd, args, { env: env ?? process.env })
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already dead */
+      }
+    }, SUB_PROBE_TIMEOUT_MS)
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (d) => (stdout += d.toString()))
+    child.stderr?.on('data', (d) => (stderr += d.toString()))
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ stdout, stderr, code })
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve({ stdout, stderr, code: null })
+    })
+  })
+
+const withTimeout = async <T>(p: Promise<T>, ms: number, fallback: T): Promise<T> => {
+  let timer: NodeJS.Timeout | null = null
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), ms)
+  })
+  try {
+    return await Promise.race([p, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+const collectMacBlock = async (): Promise<string> => {
+  const uid = process.getuid?.() ?? 0
+  const plistPath = join(homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`)
+  const plistExists = existsSync(plistPath)
+  let plistContents = '<not found>'
+  if (plistExists) {
+    try {
+      plistContents = readFileSync(plistPath, 'utf-8').trim()
+    } catch (err) {
+      plistContents = `<failed: ${(err as Error).message}>`
+    }
+  }
+  const launchdState = await withTimeout(
+    runShort('launchctl', ['print', `gui/${uid}/${LAUNCHD_LABEL}`], getPathEnv()),
+    SUB_PROBE_TIMEOUT_MS,
+    { stdout: '<failed: timeout>', stderr: '', code: null }
+  )
+  return [
+    `[macOS]`,
+    `launchd label: ${LAUNCHD_LABEL}`,
+    `plist path: ${plistPath} (${plistExists ? 'exists' : 'missing'})`,
+    `launchctl print:`,
+    launchdState.stdout.trim() || '<empty>',
+    `--- plist contents ---`,
+    plistContents
+  ].join('\n')
+}
+
+const collectWslBlock = async (): Promise<string> => {
+  const versionResult = await withTimeout(runShort('wsl', ['--version']), SUB_PROBE_TIMEOUT_MS, {
+    stdout: '<failed: timeout>',
+    stderr: '',
+    code: null
+  })
+  const listResult = await withTimeout(
+    runShort('wsl', ['--list', '--verbose']),
+    SUB_PROBE_TIMEOUT_MS,
+    { stdout: '<failed: timeout>', stderr: '', code: null }
+  )
+  const ssResult = await withTimeout(
+    runShort('wsl', [
+      '-d',
+      'Ubuntu',
+      '-u',
+      'root',
+      '--',
+      'bash',
+      '-lc',
+      `ss -ltn 2>/dev/null | grep ':${GATEWAY_PORT}' || echo '<no listener>'`
+    ]),
+    SUB_PROBE_TIMEOUT_MS,
+    { stdout: '<failed: timeout>', stderr: '', code: null }
+  )
+  const binResult = await withTimeout(
+    runShort('wsl', [
+      '-d',
+      'Ubuntu',
+      '-u',
+      'root',
+      '--',
+      'bash',
+      '-lc',
+      'command -v openclaw 2>/dev/null || echo "<not on PATH>"'
+    ]),
+    SUB_PROBE_TIMEOUT_MS,
+    { stdout: '<failed: timeout>', stderr: '', code: null }
+  )
+  return [
+    `[Windows WSL]`,
+    `wsl --version:`,
+    versionResult.stdout.trim() || versionResult.stderr.trim() || '<empty>',
+    `wsl --list --verbose:`,
+    listResult.stdout.trim() || '<empty>',
+    `WSL openclaw bin: ${binResult.stdout.trim() || '<unknown>'}`,
+    `WSL ss output for port ${GATEWAY_PORT}:`,
+    ssResult.stdout.trim() || '<empty>'
+  ].join('\n')
+}
+
+const formatHistory = (): string => {
+  const entries = getRecentEntries(60 * 60 * 1000)
+  if (entries.length === 0) return '<no restart events in last hour>'
+  return entries
+    .map((e) => {
+      const stamp = new Date(e.ts).toISOString()
+      const exit = e.exitCode === undefined ? '' : ` exit=${e.exitCode}`
+      return `${stamp} kind=${e.kind} success=${e.success}${exit}`
+    })
+    .join('\n')
+}
+
+export const collect = async (): Promise<DiagnosticReport> => {
+  const start = Date.now()
+  const supervisor = getSupervisor()
+  const lastExit = supervisor.lastExitInfo()
+  const portInfo = await withTimeout(checkPort(), SUB_PROBE_TIMEOUT_MS, { inUse: false })
+
+  const portLine = portInfo.inUse
+    ? `Port ${GATEWAY_PORT}: in use by PID ${portInfo.pid ?? '?'}`
+    : `Port ${GATEWAY_PORT}: free`
+
+  const stderrTail = lastExit?.stderrTail?.trim() || '<no recent crash output>'
+  const stdoutLines = getRecentLines(50, 'stdout').join('\n')
+
+  const platformBlock = await withTimeout(
+    platform() === 'win32' ? collectWslBlock() : collectMacBlock(),
+    Math.min(TOTAL_BUDGET_MS - (Date.now() - start), SUB_PROBE_TIMEOUT_MS * 3),
+    '<platform diagnostics timed out>'
+  )
+
+  const lines: string[] = [
+    '=== EasyClaw Gateway Diagnostic ===',
+    `Timestamp: ${new Date().toISOString()}`,
+    `EasyClaw: ${app.getVersion()}`,
+    `OS: ${platform()} ${release()} (${arch()})`,
+    `Node (host): ${process.versions.node}`,
+    `Electron: ${process.versions.electron ?? 'unknown'}`,
+    `Supervisor status: ${supervisor.getStatus()} (gaveUp=${supervisor.isGaveUp()})`,
+    `Last exit code: ${lastExit?.code ?? 'unknown'}`,
+    portLine,
+    '',
+    '--- Last gateway stderr (200 lines, PII masked) ---',
+    maskPii(stderrTail),
+    '',
+    '--- Last gateway stdout (50 lines, PII masked) ---',
+    maskPii(stdoutLines || '<empty>'),
+    '',
+    '--- Recent restart history (1 hour) ---',
+    formatHistory(),
+    '',
+    platformBlock
+  ]
+
+  return {
+    timestamp: Date.now(),
+    text: lines.join('\n')
+  }
+}

--- a/src/main/services/gateway-restart-history.ts
+++ b/src/main/services/gateway-restart-history.ts
@@ -1,0 +1,69 @@
+import { app } from 'electron'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export type RestartKind = 'auto' | 'manual'
+
+export interface RestartEntry {
+  ts: number
+  kind: RestartKind
+  success: boolean
+  exitCode?: number | null
+}
+
+const HISTORY_CAP = 200
+const WINDOW_MS = 60 * 60 * 1000
+
+let cachedPath: string | null = null
+let cached: RestartEntry[] | null = null
+
+const getHistoryPath = (): string => {
+  if (cachedPath) return cachedPath
+  cachedPath = join(app.getPath('userData'), 'gateway-restart-history.json')
+  return cachedPath
+}
+
+const load = (): RestartEntry[] => {
+  if (cached) return cached
+  try {
+    const path = getHistoryPath()
+    if (!existsSync(path)) {
+      cached = []
+      return cached
+    }
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw)
+    cached = Array.isArray(parsed) ? parsed.slice(-HISTORY_CAP) : []
+  } catch {
+    cached = []
+  }
+  return cached
+}
+
+const save = (): void => {
+  if (!cached) return
+  try {
+    writeFileSync(getHistoryPath(), JSON.stringify(cached.slice(-HISTORY_CAP)), {
+      mode: 0o600
+    })
+  } catch {
+    /* silent */
+  }
+}
+
+export const recordRestart = (entry: RestartEntry): void => {
+  const history = load()
+  history.push(entry)
+  if (history.length > HISTORY_CAP) history.splice(0, history.length - HISTORY_CAP)
+  save()
+}
+
+export const getRecentEntries = (sinceMs: number = WINDOW_MS): RestartEntry[] => {
+  const cutoff = Date.now() - sinceMs
+  return load().filter((e) => e.ts >= cutoff)
+}
+
+export const countAutoInLastHour = (): number =>
+  getRecentEntries(WINDOW_MS).filter((e) => e.kind === 'auto').length
+
+export const getAllEntries = (): RestartEntry[] => load().slice()

--- a/src/main/services/gateway-supervisor.ts
+++ b/src/main/services/gateway-supervisor.ts
@@ -5,9 +5,17 @@ import { getPathEnv, findBin } from './path-utils'
 import { WSL_NVM_INIT } from './wsl-utils'
 import { probeAlive } from './gateway-probes'
 import * as logRotator from './gateway-log-rotator'
+import { countAutoInLastHour, recordRestart } from './gateway-restart-history'
 import { t } from '../../shared/i18n/main'
 
-export type GatewayStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'failed'
+export type GatewayStatus =
+  | 'idle'
+  | 'starting'
+  | 'running'
+  | 'restarting'
+  | 'stopped'
+  | 'failed'
+  | 'gave_up'
 
 export interface ExitInfo {
   code: number | null
@@ -25,6 +33,9 @@ interface SupervisorEvents {
   died: (info: ExitInfo) => void
   started: () => void
   failed: (error: string) => void
+  restarting: (payload: { attempt: number; delayMs: number }) => void
+  restarted: () => void
+  gave_up: (payload: { attempts: number }) => void
   'status-changed': (status: GatewayStatus) => void
 }
 
@@ -32,6 +43,11 @@ const HEALTH_LOOP_MS = 5000
 const BOOT_PROBE_INTERVAL_MS = 500
 const BOOT_PROBE_MAX_MS = 15000
 const STDERR_TAIL_LINES = 200
+
+// Backoff schedule for auto-restart attempts after a crash.
+// Index 0 is the first attempt (immediate). Capped at index 4 = 60 s.
+const BACKOFF_SCHEDULE_MS = [0, 2000, 5000, 15000, 60000]
+const MAX_AUTO_RESTARTS_PER_HOUR = 5
 
 const isWindows = platform() === 'win32'
 
@@ -43,6 +59,9 @@ class GatewaySupervisor extends EventEmitter {
   private lastExit: ExitInfo | null = null
   private starting: Promise<StartResult> | null = null
   private stopping: Promise<void> | null = null
+  private gaveUp = false
+  private autoRestartTimer: NodeJS.Timeout | null = null
+  private suppressAutoRestart = false
 
   override on<K extends keyof SupervisorEvents>(event: K, listener: SupervisorEvents[K]): this {
     return super.on(event, listener)
@@ -67,20 +86,34 @@ class GatewaySupervisor extends EventEmitter {
     return probeAlive()
   }
 
-  async start(): Promise<StartResult> {
+  async start(kind: 'manual' | 'auto' = 'manual'): Promise<StartResult> {
+    if (kind === 'manual') {
+      // Manual user action clears the lock so the user can recover from gave_up.
+      this.gaveUp = false
+      this.cancelPendingAutoRestart()
+    }
     if (this.starting) return this.starting
-    this.starting = this.startInternal().finally(() => {
+    this.starting = this.startInternal(kind).finally(() => {
       this.starting = null
     })
     return this.starting
   }
 
   async stop(): Promise<void> {
+    // Treat explicit stop as user intent — do not let a death from the
+    // termination itself trigger auto-restart.
+    this.suppressAutoRestart = true
+    this.cancelPendingAutoRestart()
     if (this.stopping) return this.stopping
     this.stopping = this.stopInternal().finally(() => {
       this.stopping = null
+      this.suppressAutoRestart = false
     })
     return this.stopping
+  }
+
+  isGaveUp(): boolean {
+    return this.gaveUp
   }
 
   async restart(): Promise<StartResult> {
@@ -121,34 +154,70 @@ class GatewaySupervisor extends EventEmitter {
     this.emit('log', msg)
   }
 
-  private async startInternal(): Promise<StartResult> {
+  private async startInternal(kind: 'manual' | 'auto'): Promise<StartResult> {
     if (this.status === 'running' && (await this.isAlive())) {
       return { status: 'started' }
     }
-    this.setStatus('starting')
+    this.setStatus(kind === 'auto' ? 'restarting' : 'starting')
     try {
       const result = isWindows ? await this.startWsl() : await this.startMac()
       if (result.status === 'started') {
         const ok = await this.waitUntilAlive()
         if (!ok) {
           this.setStatus('failed')
+          recordRestart({ ts: Date.now(), kind, success: false })
           this.emit('failed', 'gateway did not become alive within 15s')
           return { status: 'error', error: 'boot probe timeout' }
         }
         this.setStatus('running')
+        recordRestart({
+          ts: Date.now(),
+          kind,
+          success: true,
+          exitCode: this.lastExit?.code ?? null
+        })
         this.emit('started')
+        if (kind === 'auto') this.emit('restarted')
         this.startHealthLoop()
       } else {
         this.setStatus('failed')
+        recordRestart({ ts: Date.now(), kind, success: false })
         this.emit('failed', result.error ?? 'unknown error')
       }
       return result
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       this.setStatus('failed')
+      recordRestart({ ts: Date.now(), kind, success: false })
       this.emit('failed', msg)
       return { status: 'error', error: msg }
     }
+  }
+
+  private cancelPendingAutoRestart(): void {
+    if (this.autoRestartTimer) {
+      clearTimeout(this.autoRestartTimer)
+      this.autoRestartTimer = null
+    }
+  }
+
+  private scheduleAutoRestart(): void {
+    if (this.suppressAutoRestart || this.gaveUp) return
+    if (this.autoRestartTimer) return // already pending
+    const attempts = countAutoInLastHour()
+    if (attempts >= MAX_AUTO_RESTARTS_PER_HOUR) {
+      this.gaveUp = true
+      this.setStatus('gave_up')
+      this.emit('gave_up', { attempts })
+      return
+    }
+    const delayMs = BACKOFF_SCHEDULE_MS[Math.min(attempts, BACKOFF_SCHEDULE_MS.length - 1)]
+    this.emit('restarting', { attempt: attempts + 1, delayMs })
+    this.setStatus('restarting')
+    this.autoRestartTimer = setTimeout(() => {
+      this.autoRestartTimer = null
+      void this.start('auto').catch(() => undefined)
+    }, delayMs)
   }
 
   private async stopInternal(): Promise<void> {
@@ -193,6 +262,7 @@ class GatewaySupervisor extends EventEmitter {
     this.logBoth(t('gateway.processExit', { code: 'unknown' }))
     this.emit('died', this.lastExit)
     this.stopHealthLoop()
+    this.scheduleAutoRestart()
   }
 
   // ---------- macOS adapter ----------
@@ -334,6 +404,7 @@ class GatewaySupervisor extends EventEmitter {
           this.setStatus('stopped')
           this.emit('died', this.lastExit)
           this.stopHealthLoop()
+          this.scheduleAutoRestart()
         }
       })
 

--- a/src/main/services/tray-manager.ts
+++ b/src/main/services/tray-manager.ts
@@ -1,11 +1,17 @@
-import { Tray, Menu, nativeImage, Notification, BrowserWindow } from 'electron'
+import { Tray, Menu, nativeImage, Notification, BrowserWindow, clipboard } from 'electron'
 import { join } from 'path'
 import { getGatewayStatus, startGateway, stopGateway } from './gateway'
+import { getSupervisor, type GatewayStatus } from './gateway-supervisor'
+import { collect as collectDiagnostic } from './diagnostic-collector'
 import { t } from '../../shared/i18n/main'
 
 let tray: Tray | null = null
 let pollTimer: ReturnType<typeof setInterval> | null = null
-let lastStatus: 'running' | 'stopped' = 'stopped'
+let lastStatus: TrayStatus = 'stopped'
+let lastNotifyMs = 0
+let supervisorSubscribed = false
+
+type TrayStatus = 'running' | 'restarting' | 'failed' | 'stopped'
 
 interface TrayDeps {
   getWin: () => BrowserWindow | null
@@ -33,7 +39,24 @@ const createTrayIcon = (): Electron.NativeImage => {
   return img.resize({ width: 16, height: 16 })
 }
 
-const buildMenu = (status: 'running' | 'stopped'): Menu =>
+const statusLabel = (status: TrayStatus): string => {
+  switch (status) {
+    case 'running':
+      return t('tray.gwRunning')
+    case 'restarting':
+      return t('tray.gwRestarting')
+    case 'failed':
+      return t('tray.gwFailed')
+    case 'stopped':
+    default:
+      return t('tray.gwStopped')
+  }
+}
+
+const tooltipFor = (status: TrayStatus): string =>
+  status === 'running' ? t('tray.tooltipRunning') : t('tray.tooltipStopped')
+
+const buildMenu = (status: TrayStatus): Menu =>
   Menu.buildFromTemplate([
     {
       label: t('tray.open'),
@@ -46,13 +69,10 @@ const buildMenu = (status: 'running' | 'stopped'): Menu =>
       }
     },
     { type: 'separator' },
-    {
-      label: status === 'running' ? t('tray.gwRunning') : t('tray.gwStopped'),
-      enabled: false
-    },
+    { label: statusLabel(status), enabled: false },
     {
       label: t('tray.gwStart'),
-      enabled: status === 'stopped',
+      enabled: status !== 'running' && status !== 'restarting',
       click: async () => {
         try {
           await startGateway()
@@ -64,10 +84,23 @@ const buildMenu = (status: 'running' | 'stopped'): Menu =>
     },
     {
       label: t('tray.gwStop'),
-      enabled: status === 'running',
+      enabled: status === 'running' || status === 'restarting',
       click: async () => {
         await stopGateway()
         await refreshStatus()
+      }
+    },
+    { type: 'separator' },
+    {
+      label: t('tray.copyDiagnostic'),
+      click: async () => {
+        try {
+          const report = await collectDiagnostic()
+          clipboard.writeText(report.text)
+          notify('EasyClaw', '진단 정보를 클립보드에 복사했습니다.')
+        } catch {
+          /* ignore */
+        }
       }
     },
     { type: 'separator' },
@@ -79,31 +112,64 @@ const buildMenu = (status: 'running' | 'stopped'): Menu =>
     }
   ])
 
+const computeTrayStatus = (
+  pollResult: 'running' | 'stopped',
+  supervisorStatus: GatewayStatus
+): TrayStatus => {
+  if (supervisorStatus === 'restarting') return 'restarting'
+  if (supervisorStatus === 'gave_up' || supervisorStatus === 'failed') return 'failed'
+  return pollResult
+}
+
 const refreshStatus = async (): Promise<void> => {
-  const status = await getGatewayStatus()
+  const pollResult = await getGatewayStatus()
+  const supervisorStatus = getSupervisor().getStatus()
+  const status = computeTrayStatus(pollResult, supervisorStatus)
   updateMenu(status)
 
   if (status !== lastStatus) {
     lastStatus = status
-    const win = deps?.getWin()
-    if (win && !win.isDestroyed()) {
-      win.webContents.send('gateway:status-changed', status)
-    }
-    const msg = status === 'running' ? t('tray.notifyRunning') : t('tray.notifyStopped')
-    notify('Gateway', msg)
+    if (status === 'running') notify('Gateway', t('tray.notifyRunning'))
+    else if (status === 'stopped') notify('Gateway', t('tray.notifyStopped'))
   }
 }
 
-const updateMenu = (status: 'running' | 'stopped'): void => {
+const updateMenu = (status: TrayStatus): void => {
   if (!tray) return
   tray.setContextMenu(buildMenu(status))
-  tray.setToolTip(status === 'running' ? t('tray.tooltipRunning') : t('tray.tooltipStopped'))
+  tray.setToolTip(tooltipFor(status))
 }
 
+const NOTIFY_THROTTLE_MS = 5 * 60 * 1000
 const notify = (title: string, body: string): void => {
+  const now = Date.now()
+  if (now - lastNotifyMs < NOTIFY_THROTTLE_MS) return
+  lastNotifyMs = now
   if (Notification.isSupported()) {
     new Notification({ title, body }).show()
   }
+}
+
+const subscribeSupervisor = (): void => {
+  if (supervisorSubscribed) return
+  supervisorSubscribed = true
+  const supervisor = getSupervisor()
+  supervisor.on('died', () => {
+    notify('Gateway', t('tray.notifyDied'))
+    void refreshStatus()
+  })
+  supervisor.on('gave_up', () => {
+    // Bypass throttle for gave_up — user must see this.
+    lastNotifyMs = 0
+    notify('Gateway', t('tray.notifyGaveUp'))
+    const win = deps?.getWin()
+    if (win && !win.isDestroyed()) {
+      win.show()
+      win.focus()
+    }
+    void refreshStatus()
+  })
+  supervisor.on('status-changed', () => void refreshStatus())
 }
 
 export const createTray = (trayDeps: TrayDeps): void => {
@@ -112,6 +178,7 @@ export const createTray = (trayDeps: TrayDeps): void => {
   tray = new Tray(icon)
   tray.setToolTip('EasyClaw')
   updateMenu('stopped')
+  subscribeSupervisor()
 
   if (process.platform === 'darwin') {
     tray.on('click', () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -51,7 +51,19 @@ interface ElectronAPI {
     restart: () => Promise<{ success: boolean; error?: string }>
     status: () => Promise<'running' | 'stopped'>
     onLog: (cb: (msg: string) => void) => () => void
-    onStatusChanged: (cb: (status: 'running' | 'stopped') => void) => () => void
+    onStatusChanged: (
+      cb: (payload: {
+        status: 'idle' | 'starting' | 'running' | 'restarting' | 'stopped' | 'failed' | 'gave_up'
+      }) => void
+    ) => () => void
+    onRestarting: (cb: (payload: { attempt: number; delayMs: number }) => void) => () => void
+    onRestarted: (cb: () => void) => () => void
+    onGaveUp: (cb: (payload: { attempts: number }) => void) => () => void
+    onDied: (cb: (info: { code: number | null; ts: number }) => void) => () => void
+  }
+  diagnostic: {
+    collect: () => Promise<{ timestamp: number; text: string }>
+    copy: (text: string) => Promise<{ success: boolean; error?: string }>
   }
   troubleshoot: {
     checkPort: () => Promise<{ inUse: boolean; pid?: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -61,11 +61,46 @@ const electronAPI = {
       ipcRenderer.on('gateway:log', handler)
       return () => ipcRenderer.removeListener('gateway:log', handler)
     },
-    onStatusChanged: (cb: (status: 'running' | 'stopped') => void): (() => void) => {
-      const handler = (_: unknown, s: 'running' | 'stopped'): void => cb(s)
+    onStatusChanged: (
+      cb: (payload: {
+        status: 'idle' | 'starting' | 'running' | 'restarting' | 'stopped' | 'failed' | 'gave_up'
+      }) => void
+    ): (() => void) => {
+      const handler = (
+        _: unknown,
+        payload: {
+          status: 'idle' | 'starting' | 'running' | 'restarting' | 'stopped' | 'failed' | 'gave_up'
+        }
+      ): void => cb(payload)
       ipcRenderer.on('gateway:status-changed', handler)
       return () => ipcRenderer.removeListener('gateway:status-changed', handler)
+    },
+    onRestarting: (cb: (payload: { attempt: number; delayMs: number }) => void): (() => void) => {
+      const handler = (_: unknown, p: { attempt: number; delayMs: number }): void => cb(p)
+      ipcRenderer.on('gateway:restarting', handler)
+      return () => ipcRenderer.removeListener('gateway:restarting', handler)
+    },
+    onRestarted: (cb: () => void): (() => void) => {
+      const handler = (): void => cb()
+      ipcRenderer.on('gateway:restarted', handler)
+      return () => ipcRenderer.removeListener('gateway:restarted', handler)
+    },
+    onGaveUp: (cb: (payload: { attempts: number }) => void): (() => void) => {
+      const handler = (_: unknown, p: { attempts: number }): void => cb(p)
+      ipcRenderer.on('gateway:gave-up', handler)
+      return () => ipcRenderer.removeListener('gateway:gave-up', handler)
+    },
+    onDied: (cb: (info: { code: number | null; ts: number }) => void): (() => void) => {
+      const handler = (_: unknown, info: { code: number | null; ts: number }): void => cb(info)
+      ipcRenderer.on('gateway:died', handler)
+      return () => ipcRenderer.removeListener('gateway:died', handler)
     }
+  },
+  diagnostic: {
+    collect: (): Promise<{ timestamp: number; text: string }> =>
+      ipcRenderer.invoke('diagnostic:collect'),
+    copy: (text: string): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke('diagnostic:copy', text)
   },
   troubleshoot: {
     checkPort: (): Promise<{ inUse: boolean; pid?: string }> =>

--- a/src/renderer/src/components/DiagnosticModal.tsx
+++ b/src/renderer/src/components/DiagnosticModal.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Button from './Button'
+
+const KAKAO_OPENCHAT_URL = 'https://open.kakao.com/o/gbBkPehi'
+
+export default function DiagnosticModal({
+  open,
+  onClose,
+  onRetry
+}: {
+  open: boolean
+  onClose: () => void
+  onRetry?: () => void
+}): React.JSX.Element | null {
+  const { t } = useTranslation('management')
+  const [text, setText] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    const run = async (): Promise<void> => {
+      setLoading(true)
+      setCopied(false)
+      try {
+        const report = await window.electronAPI.diagnostic.collect()
+        if (cancelled) return
+        setText(report.text)
+      } catch {
+        if (cancelled) return
+        setText('<failed to collect diagnostic info>')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  const handleCopy = async (): Promise<void> => {
+    const result = await window.electronAPI.diagnostic.copy(text)
+    if (result.success) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="glass-card w-full max-w-2xl mx-4 p-6 space-y-4">
+        <div>
+          <h3 className="text-base font-black">{t('done.failureModal.title')}</h3>
+          <p className="text-sm text-text-muted mt-2">{t('done.failureModal.body')}</p>
+        </div>
+
+        <div className="bg-bg-card border border-text-muted/20 rounded-md p-3 max-h-64 overflow-auto">
+          <pre className="text-[11px] text-text-muted whitespace-pre-wrap font-mono">
+            {loading ? '...' : text}
+          </pre>
+        </div>
+
+        <div className="flex flex-wrap gap-2 justify-end">
+          {onRetry && (
+            <Button variant="secondary" size="sm" onClick={onRetry}>
+              {t('done.failureModal.retry')}
+            </Button>
+          )}
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            {t('modal.close')}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => window.open(KAKAO_OPENCHAT_URL, '_blank')}
+          >
+            {t('done.failureModal.openKakao')}
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleCopy} disabled={loading}>
+            {copied ? t('done.diagnosticCopied') : t('done.failureModal.copy')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/steps/DoneStep.tsx
+++ b/src/renderer/src/steps/DoneStep.tsx
@@ -6,6 +6,7 @@ import Button from '../components/Button'
 import LogViewer from '../components/LogViewer'
 import ManagementModal from '../components/ManagementModal'
 import ProviderSwitchModal from '../components/ProviderSwitchModal'
+import DiagnosticModal from '../components/DiagnosticModal'
 import LanguageSwitcher from '../components/LanguageSwitcher'
 import { useManagement } from '../hooks/useManagement'
 
@@ -22,6 +23,8 @@ export default function DoneStep({
 }): React.JSX.Element {
   const { t } = useTranslation('management')
   const [status, setStatus] = useState<'starting' | 'running' | 'stopped'>('starting')
+  const [gatewayHealth, setGatewayHealth] = useState<'healthy' | 'restarting' | 'failed'>('healthy')
+  const [showDiagnosticModal, setShowDiagnosticModal] = useState(false)
   const [hasError, setHasError] = useState(false)
   const [logs, setLogs] = useState<string[]>([])
   const [showLogs, setShowLogs] = useState(false)
@@ -132,10 +135,32 @@ export default function DoneStep({
 
   // Subscribe to Gateway status changes from tray
   useEffect(() => {
-    const unsub = window.electronAPI.gateway.onStatusChanged((s) => {
+    const unsub = window.electronAPI.gateway.onStatusChanged(({ status: s }) => {
       setStatus(s === 'running' ? 'running' : 'stopped')
+      if (s === 'running') setGatewayHealth('healthy')
+      else if (s === 'restarting') setGatewayHealth('restarting')
+      else if (s === 'failed' || s === 'gave_up') setGatewayHealth('failed')
     })
     return unsub
+  }, [])
+
+  // Subscribe to richer supervisor events for restart UX + failure modal
+  useEffect(() => {
+    const unsubRestarting = window.electronAPI.gateway.onRestarting(() => {
+      setGatewayHealth('restarting')
+    })
+    const unsubRestarted = window.electronAPI.gateway.onRestarted(() => {
+      setGatewayHealth('healthy')
+    })
+    const unsubGaveUp = window.electronAPI.gateway.onGaveUp(() => {
+      setGatewayHealth('failed')
+      setShowDiagnosticModal(true)
+    })
+    return () => {
+      unsubRestarting()
+      unsubRestarted()
+      unsubGaveUp()
+    }
   }, [])
 
   useEffect(() => {
@@ -412,6 +437,13 @@ export default function DoneStep({
           <span className="text-[11px] font-bold flex-1 text-left">{t('done.restore')}</span>
         </button>
         <button
+          onClick={() => setShowDiagnosticModal(true)}
+          className="glass-card flex items-center gap-2 px-3 py-2 cursor-pointer hover:border-primary/40 transition-all duration-200"
+        >
+          <span className="text-sm">🔧</span>
+          <span className="text-[11px] font-bold flex-1 text-left">{t('done.copyDiagnostic')}</span>
+        </button>
+        <button
           onClick={uninstall.open}
           className="glass-card flex items-center gap-2 px-3 py-2 cursor-pointer hover:border-error/40 transition-all duration-200"
         >
@@ -421,6 +453,34 @@ export default function DoneStep({
           </span>
         </button>
       </div>
+
+      {/* ─── Auto-restart / failure banner ─── */}
+      {gatewayHealth === 'restarting' && (
+        <div className="w-full max-w-md bg-warning/10 border border-warning/30 rounded-md px-3 py-2">
+          <p className="text-xs text-warning">{t('done.gatewayRestarting')}</p>
+        </div>
+      )}
+      {gatewayHealth === 'failed' && (
+        <div className="w-full max-w-md bg-error/10 border border-error/30 rounded-md px-3 py-2 flex items-center justify-between gap-3">
+          <p className="text-xs text-error">{t('done.gatewayFailed')}</p>
+          <Button variant="secondary" size="sm" onClick={() => setShowDiagnosticModal(true)}>
+            {t('done.copyDiagnostic')}
+          </Button>
+        </div>
+      )}
+
+      <DiagnosticModal
+        open={showDiagnosticModal}
+        onClose={() => setShowDiagnosticModal(false)}
+        onRetry={async () => {
+          setShowDiagnosticModal(false)
+          setGatewayHealth('healthy')
+          setStatus('starting')
+          const r = await window.electronAPI.gateway.start()
+          setStatus(r.success ? 'running' : 'stopped')
+          if (!r.success) setGatewayHealth('failed')
+        }}
+      />
 
       {/* ─── Uninstall modal ─── */}
       {uninstall.modal && (

--- a/src/shared/i18n/locales/en/main.json
+++ b/src/shared/i18n/locales/en/main.json
@@ -43,12 +43,17 @@
   "tray": {
     "open": "Open EasyClaw",
     "gwRunning": "Gateway Running",
+    "gwRestarting": "Gateway Restarting...",
+    "gwFailed": "Gateway Failed (max restarts reached)",
     "gwStopped": "Gateway Stopped",
     "gwStart": "Start Gateway",
     "gwStop": "Stop Gateway",
+    "copyDiagnostic": "🔧 Copy Diagnostic Info",
     "quit": "Quit",
     "notifyRunning": "Gateway is running",
     "notifyStopped": "Gateway has stopped",
+    "notifyDied": "Gateway just exited — auto-restarting now",
+    "notifyGaveUp": "Gateway failed to restart 5 times. Check the diagnostic info.",
     "tooltipRunning": "EasyClaw - Gateway Running",
     "tooltipStopped": "EasyClaw - Gateway Stopped"
   },

--- a/src/shared/i18n/locales/en/management.json
+++ b/src/shared/i18n/locales/en/management.json
@@ -24,7 +24,18 @@
     "delete": "Delete",
     "restartingGw": "Restarting Gateway...",
     "errorPrefix": "[Error] {{msg}}",
-    "settingsBackup": "Settings Backup"
+    "settingsBackup": "Settings Backup",
+    "gatewayRestarting": "Gateway auto-restarting...",
+    "gatewayFailed": "Gateway restart failed",
+    "copyDiagnostic": "🔧 Copy Diagnostic Info",
+    "diagnosticCopied": "Copied!",
+    "failureModal": {
+      "title": "Gateway failed to restart 5 times",
+      "body": "Diagnostic info was collected automatically. Paste it into the Kakao group chat and we'll get back to you quickly.",
+      "copy": "Copy to Clipboard",
+      "openKakao": "Open Kakao Group Chat",
+      "retry": "Retry"
+    }
   },
   "uninstall": {
     "title": "Uninstall OpenClaw",

--- a/src/shared/i18n/locales/ja/main.json
+++ b/src/shared/i18n/locales/ja/main.json
@@ -43,12 +43,17 @@
   "tray": {
     "open": "EasyClawを開く",
     "gwRunning": "Gateway実行中",
+    "gwRestarting": "Gateway再起動中...",
+    "gwFailed": "Gateway失敗（再起動回数上限）",
     "gwStopped": "Gateway停止中",
     "gwStart": "Gatewayを開始",
     "gwStop": "Gatewayを停止",
+    "copyDiagnostic": "🔧 診断情報をコピー",
     "quit": "終了",
     "notifyRunning": "Gatewayが実行中です",
     "notifyStopped": "Gatewayが停止しました",
+    "notifyDied": "Gatewayが終了しました。自動再起動中です",
+    "notifyGaveUp": "Gatewayの再起動が5回失敗しました。診断情報を確認してください。",
     "tooltipRunning": "EasyClaw - Gateway実行中",
     "tooltipStopped": "EasyClaw - Gateway停止中"
   },

--- a/src/shared/i18n/locales/ja/management.json
+++ b/src/shared/i18n/locales/ja/management.json
@@ -24,7 +24,18 @@
     "delete": "削除",
     "restartingGw": "Gatewayを再起動中...",
     "errorPrefix": "[エラー] {{msg}}",
-    "settingsBackup": "設定のバックアップ"
+    "settingsBackup": "設定のバックアップ",
+    "gatewayRestarting": "Gatewayを自動再起動中...",
+    "gatewayFailed": "Gateway再起動失敗",
+    "copyDiagnostic": "🔧 診断情報をコピー",
+    "diagnosticCopied": "コピーしました!",
+    "failureModal": {
+      "title": "Gatewayの再起動が5回失敗しました",
+      "body": "診断情報を自動収集しました。カカオグループチャットに貼り付けていただければ、迅速に対応します。",
+      "copy": "クリップボードにコピー",
+      "openKakao": "カカオグループチャットを開く",
+      "retry": "再試行"
+    }
   },
   "uninstall": {
     "title": "OpenClawの削除",

--- a/src/shared/i18n/locales/ko/main.json
+++ b/src/shared/i18n/locales/ko/main.json
@@ -43,12 +43,17 @@
   "tray": {
     "open": "EasyClaw 열기",
     "gwRunning": "Gateway 실행 중",
+    "gwRestarting": "Gateway 재시작 중...",
+    "gwFailed": "Gateway 실패 (재시작 한도 초과)",
     "gwStopped": "Gateway 중지됨",
     "gwStart": "Gateway 시작",
     "gwStop": "Gateway 중지",
+    "copyDiagnostic": "🔧 진단 정보 복사",
     "quit": "종료",
     "notifyRunning": "Gateway가 실행 중입니다",
     "notifyStopped": "Gateway가 중지되었습니다",
+    "notifyDied": "Gateway가 방금 종료되어 자동 재시작 중입니다",
+    "notifyGaveUp": "Gateway가 5번 재시작에 실패했습니다. 진단 정보를 확인하세요.",
     "tooltipRunning": "EasyClaw - Gateway 실행 중",
     "tooltipStopped": "EasyClaw - Gateway 중지됨"
   },

--- a/src/shared/i18n/locales/ko/management.json
+++ b/src/shared/i18n/locales/ko/management.json
@@ -24,7 +24,18 @@
     "delete": "삭제",
     "restartingGw": "Gateway 재시작 중...",
     "errorPrefix": "[오류] {{msg}}",
-    "settingsBackup": "설정 백업"
+    "settingsBackup": "설정 백업",
+    "gatewayRestarting": "Gateway 자동 재시작 중...",
+    "gatewayFailed": "Gateway 재시작 실패",
+    "copyDiagnostic": "🔧 진단 정보 복사",
+    "diagnosticCopied": "복사됨!",
+    "failureModal": {
+      "title": "Gateway가 5번 재시작에 실패했어요",
+      "body": "진단 정보를 자동으로 모았습니다. 카카오 단톡방에 붙여넣어 알려주시면 빠르게 해결해드립니다.",
+      "copy": "클립보드 복사",
+      "openKakao": "카카오 단톡방 열기",
+      "retry": "재시도"
+    }
   },
   "uninstall": {
     "title": "OpenClaw 삭제",

--- a/src/shared/i18n/locales/zh/main.json
+++ b/src/shared/i18n/locales/zh/main.json
@@ -43,12 +43,17 @@
   "tray": {
     "open": "打开 EasyClaw",
     "gwRunning": "Gateway 运行中",
+    "gwRestarting": "Gateway 重启中...",
+    "gwFailed": "Gateway 失败（已达重启上限）",
     "gwStopped": "Gateway 已停止",
     "gwStart": "启动 Gateway",
     "gwStop": "停止 Gateway",
+    "copyDiagnostic": "🔧 复制诊断信息",
     "quit": "退出",
     "notifyRunning": "Gateway 正在运行",
     "notifyStopped": "Gateway 已停止",
+    "notifyDied": "Gateway 刚刚退出 — 正在自动重启",
+    "notifyGaveUp": "Gateway 重启失败 5 次。请查看诊断信息。",
     "tooltipRunning": "EasyClaw - Gateway 运行中",
     "tooltipStopped": "EasyClaw - Gateway 已停止"
   },

--- a/src/shared/i18n/locales/zh/management.json
+++ b/src/shared/i18n/locales/zh/management.json
@@ -24,7 +24,18 @@
     "delete": "删除",
     "restartingGw": "正在重启 Gateway...",
     "errorPrefix": "[错误] {{msg}}",
-    "settingsBackup": "配置备份"
+    "settingsBackup": "配置备份",
+    "gatewayRestarting": "Gateway 正在自动重启...",
+    "gatewayFailed": "Gateway 重启失败",
+    "copyDiagnostic": "🔧 复制诊断信息",
+    "diagnosticCopied": "已复制!",
+    "failureModal": {
+      "title": "Gateway 重启失败 5 次",
+      "body": "已自动收集诊断信息。请粘贴到 Kakao 群聊中，我们将尽快为您处理。",
+      "copy": "复制到剪贴板",
+      "openKakao": "打开 Kakao 群聊",
+      "retry": "重试"
+    }
   },
   "uninstall": {
     "title": "删除 OpenClaw",


### PR DESCRIPTION
## Summary

PR-2 of two for **v1.3.39**, building on #10. Where PR-1 stayed
behind the curtain (lifecycle, logging, plist migration), this PR is
what users actually see when the gateway dies.

- **Auto-restart with backoff** — supervisor reacts to its own \`'died'\` event with delays \`0 / 2 / 5 / 15 / 60 s\`, capped at 5 attempts in any 1-hour window. The cap survives app restarts via \`gateway-restart-history.json\`. Manual actions clear the cap so users can recover from \`gave_up\`.
- **Diagnostic collector + copy button** — one click in DoneStep or the tray gathers the last 200 stderr lines, recent stdout, restart history, port owner, OS / Node / Electron info, and platform-specific bits (\`launchctl print\` on macOS, \`wsl --version\` + ss output inside the distro on Windows). All Telegram bot tokens, \`sk-…\`, \`sk-ant-…\`, and \`AIza…\` strings are masked before leaving the collector. Plan said clipboard + Kakao open chat is the right channel here — no auto-upload, no bot tokens to embed.
- **3-state tray** — label flips to "Gateway 재시작 중..." or "Gateway 실패 (재시작 한도 초과)" when appropriate, with throttled notifications (\`died\` capped at 5 min, \`gave_up\` always fires and surfaces the main window).
- **DoneStep failure modal** — auto-opens on \`gave_up\` with the diagnostic text, copy / Kakao / retry buttons.
- **Boot-order race fix** — \`onboard:run\` and \`config:switch-provider\` now await \`supervisor.start()\` so DoneStep mounts with an alive gateway and \`switchProvider\` boots the daemon exactly once instead of twice.
- **i18n** for ko / en / ja / zh.
- **Version bump** \`1.3.38 → 1.3.39\` + \`docs/QA-1.3.39.md\` checklist.

Base branch: \`feat/gateway-supervisor\` (PR #10). Merge order: PR-1 first, then this.

## Test plan

See \`docs/QA-1.3.39.md\` for the full 7-scenario manual checklist (force-kill, crash loop, post-onboard alive, single boot on switchProvider, quit cleanup, log rotation, PII masking).

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors, only the unchanged LobsterLogo prettier warning
- [ ] macOS smoke: \`pkill -9 -f openclaw-gateway\` 5× → tray flips to "failed", DiagnosticModal opens, "Copy" puts a complete masked report on the clipboard
- [ ] Windows WSL: \`wsl -d Ubuntu -u root -- pkill -9 -f openclaw\` → auto-restart fires within ~5 s
- [ ] Plug a fake \`bot1234567890:AAFAKE…\` token into stderr → masked as \`****MASKED****\` in diagnostic output